### PR TITLE
Load WikibaseImport via wfLoadExtension in Travis

### DIFF
--- a/build/travis/before_script.sh
+++ b/build/travis/before_script.sh
@@ -58,7 +58,7 @@ echo '$wgLanguageCode = "en";' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/Wikibase.php";' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/repo/ExampleSettings.php";' >> LocalSettings.php
 echo 'require_once __DIR__ . "/extensions/Wikibase/client/WikibaseClient.php";' >> LocalSettings.php
-echo 'require_once __DIR__ . "/extensions/WikibaseImport/WikibaseImport.php";' >> LocalSettings.php
+echo 'wfLoadExtension( "WikibaseImport" );' >> LocalSettings.php
 echo '$wgWBClientSettings["siteGlobalID"] = "enwiki";' >> LocalSettings.php
 
 php maintenance/update.php --quick


### PR DESCRIPTION
---

This probably won’t fix the Travis builds, but at least it’ll shut up a noisy warning in the logs.