### PR TITLE
Declare compatibility with Monolog v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": ">=5.5.0",
 		"benestar/asparagus": "~0.4",
-		"monolog/monolog": "~1.18",
+		"monolog/monolog": "~1.18||^2.0.0",
 		"wikibase/data-model": "~6.0|~7.0|~8.0|~9.0"
 	},
 	"autoload": {


### PR DESCRIPTION
This is required when using this extension with MediaWiki 1.36. None of the breaking changes in Monolog 2.0.0 should affect this extension, as far as I can tell.

---

I’ve had this locally for a while, figured I’d upload it.